### PR TITLE
Allow missing space before/after colon

### DIFF
--- a/src/server/problem/parser.py
+++ b/src/server/problem/parser.py
@@ -4,7 +4,7 @@ from util import flat_map, flatten
 
 
 def split_config(config: str) -> List[str]:
-    res = flatten([x.split(" ") for x in config.split(" : ")])
+    res = flatten([x.strip().split(" ") for x in config.split(":")])
     return [x for x in res if x.strip() != ""]
 
 


### PR DESCRIPTION
To keep versions in sync. :)